### PR TITLE
Remove 48th ward neighbors for justice

### DIFF
--- a/_pages/en/organizations.md
+++ b/_pages/en/organizations.md
@@ -6,9 +6,8 @@ description: CTM is a coalition. Learn about who powers us.
 
 ### Community organizations
 
-We're powered by our members. Participating organizations include: 
+We're powered by our members. Participating organizations include:
 
-- [48th Ward Neighbors for Justice](https://48thneighbors.org/)
 - [Albany Park Mutual Aid](https://www.albanyparkmutualaid.com/)
 - [Autonomous Tenants Union](https://www.autonomoustenantsunion.org/)
 - [Chicago DSA](https://www.chicagodsa.org/)

--- a/_pages/es/organizaciones.md
+++ b/_pages/es/organizaciones.md
@@ -8,7 +8,6 @@ description: CTM es una coalición. Aprenda quién nos impulsa.
 
 Somos impulsados ​​por nuestros miembros. Las organizaciones participantes incluyen:
 
-- [48th Ward Neighbors for Justice](https://48thneighbors.org/)
 - [Albany Park Mutual Aid](https://www.albanyparkmutualaid.com/)
 - [Autonomous Tenants Union](https://es.autonomoustenantsunion.org/)
 - [Chicago DSA](https://www.chicagodsa.org/)


### PR DESCRIPTION
Removes 48th Ward Neighbors for Justice from list of constituent orgs.